### PR TITLE
Update AppGroup authorization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     hirb (0.7.3)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.0.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     iniparse (1.4.4)
     io-like (0.3.0)
@@ -226,7 +226,7 @@ GEM
     mini_portile2 (2.3.0)
     minitar (0.6.1)
     minitest (5.11.3)
-    mixlib-archive (0.4.8)
+    mixlib-archive (0.4.13)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
@@ -234,7 +234,7 @@ GEM
       tomlrb
     mixlib-log (2.0.4)
     mixlib-shellout (2.4.0)
-    molinillo (0.6.5)
+    molinillo (0.6.6)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -247,7 +247,7 @@ GEM
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    net-telnet (0.1.1)
+    net-telnet (0.2.0)
     netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.8.4)
@@ -361,7 +361,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-rspec (1.25.0)
       rubocop (>= 0.53.0)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubycas-client (2.3.9)
       activesupport
@@ -384,7 +384,7 @@ GEM
       faraday (~> 0.8, < 1.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
-    selenium-webdriver (3.13.1)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
     semverse (2.0.0)
@@ -418,7 +418,7 @@ GEM
     solve (4.0.0)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.75.0)
+    specinfra (2.75.1)
       net-scp
       net-ssh (>= 2.7)
       net-telnet
@@ -453,7 +453,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.16)
+    uglifier (4.1.17)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -16,7 +16,9 @@ var users = {
         processResults: function(data) {
           return {
             results: $.map(data, function(user, i) {
-              return { id: user.id, text: user.username + " - " + user.email }
+              text = user.username;
+              if (!text) text = user.email;
+              return { id: user.id, text: text }
             })
           };
         }

--- a/app/controllers/app_groups_controller.rb
+++ b/app/controllers/app_groups_controller.rb
@@ -56,11 +56,9 @@ class AppGroupsController < ApplicationController
   private
 
   def app_group_params
-    params[:app_group][:user_id] = current_user.id
     params.require(:app_group).permit(
       :name,
-      :capacity,
-      :user_id
+      :capacity
     )
   end
 

--- a/app/controllers/app_groups_controller.rb
+++ b/app/controllers/app_groups_controller.rb
@@ -17,8 +17,8 @@ class AppGroupsController < ApplicationController
   def show
     @apps = @app_group.barito_apps
     @app = BaritoApp.new
-    @allow_action = policy(@app_group).allow_action?
-    @allow_upgrade = policy(@app_group).allow_upgrade?
+    @allow_manage_access = policy(@app_group).manage_access?
+    @allow_see_infrastructure = policy(Infrastructure).show?
     @allow_see_apps = policy(@app_group).allow_see_apps?
     @allow_delete_barito_app = policy(@app).delete?
     @allow_add_barito_app = policy(@app).create?

--- a/app/controllers/app_groups_controller.rb
+++ b/app/controllers/app_groups_controller.rb
@@ -6,6 +6,7 @@ class AppGroupsController < ApplicationController
 
   def index
     @app_groups = policy_scope(AppGroup)
+    @allow_create_app_group = policy(Group).index?
   end
 
   def search
@@ -18,16 +19,19 @@ class AppGroupsController < ApplicationController
     @app = BaritoApp.new
     @allow_action = policy(@app_group).allow_action?
     @allow_upgrade = policy(@app_group).allow_upgrade?
+    @allow_see_apps = policy(@app_group).allow_see_apps?
     @allow_delete_barito_app = policy(@app).delete?
     @allow_add_barito_app = policy(@app).create?
   end
 
   def new
+    authorize AppGroup
     @app_group = AppGroup.new
     @capacity_options = TPS_CONFIG.keys
   end
 
   def create
+    authorize AppGroup
     @app_group, @infrastructure = AppGroup.setup(Rails.env, app_group_params)
     if @app_group.valid? && @infrastructure.valid?
       return redirect_to root_path

--- a/app/controllers/infrastructures_controller.rb
+++ b/app/controllers/infrastructures_controller.rb
@@ -1,16 +1,25 @@
 class InfrastructuresController < ApplicationController
+  before_action :set_infrastructure
+  before_action  do
+    authorize @infrastructure
+  end
+
   def show
-    @infrastructure = Infrastructure.find(params[:id])
     @infrastructure_components = @infrastructure.infrastructure_components.order(:sequence)
   end
 
   def retry_bootstrap
-    @infrastructure = Infrastructure.find(params[:id])
     @infrastructure_component = InfrastructureComponent.find(
       params[:infrastructure_component_id])
     if @infrastructure_component.allow_bootstrap?
       RetryBootstrapWorker.perform_async(@infrastructure_component.id)
     end
     redirect_to infrastructure_path(@infrastructure.id)
+  end
+
+  private
+
+  def set_infrastructure
+    @infrastructure = Infrastructure.find(params[:id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,5 @@
+module ApplicationHelper
+  def allow_manage_groups?
+    policy(Group).index?
+  end
+end

--- a/app/models/app_group.rb
+++ b/app/models/app_group.rb
@@ -1,7 +1,6 @@
 class AppGroup < ApplicationRecord
   validates :name, presence: true
 
-  belongs_to :created_by, foreign_key: :created_by_id, class_name: 'User'
   has_many :barito_apps
   has_many :app_group_users
   has_many :users, through: :app_group_users
@@ -9,7 +8,7 @@ class AppGroup < ApplicationRecord
 
   def self.setup(env, params)
     ActiveRecord::Base.transaction do
-      app_group = AppGroup.create(name: params[:name], created_by_id: params[:user_id])
+      app_group = AppGroup.create(name: params[:name])
       infrastructure = Infrastructure.setup(
         env,
         name: params[:name],

--- a/app/policies/app_group_policy.rb
+++ b/app/policies/app_group_policy.rb
@@ -51,15 +51,4 @@ class AppGroupPolicy < ApplicationPolicy
       scope.where(id: app_group_ids)
     end
   end
-
-  private
-
-  def get_user_groups
-    if Figaro.env.enable_cas_integration == 'true'
-      gate_groups = GateWrapper.new(user).check_user_groups.symbolize_keys[:groups] || []
-      return true if Group.where(name: gate_groups).count > 0
-    else
-      return true if user.groups.count > 0
-    end
-  end
 end

--- a/app/policies/app_group_policy.rb
+++ b/app/policies/app_group_policy.rb
@@ -10,7 +10,6 @@ class AppGroupPolicy < ApplicationPolicy
 
   def show?
     return true if get_user_groups
-    return true if record.created_by == user
 
     app_group_ids = AppGroupUser.where(user: user).pluck(:app_group_id)
     app_group_ids.include?(record.id)
@@ -18,7 +17,6 @@ class AppGroupPolicy < ApplicationPolicy
 
   def manage_access?
     return true if get_user_groups
-    return true if record.created_by == user
 
     AppGroupUser.
       joins(:role).
@@ -31,7 +29,6 @@ class AppGroupPolicy < ApplicationPolicy
 
   def allow_upgrade?
     return true if get_user_groups
-    return true if record.created_by == user
 
     AppGroupUser.
       joins(:role).
@@ -51,8 +48,7 @@ class AppGroupPolicy < ApplicationPolicy
       end
 
       app_group_ids = AppGroupUser.where(user: user).pluck(:app_group_id)
-      scope.where(created_by: user).
-        or(scope.where(id: app_group_ids))
+      scope.where(id: app_group_ids)
     end
   end
 

--- a/app/policies/app_group_policy.rb
+++ b/app/policies/app_group_policy.rb
@@ -23,21 +23,10 @@ class AppGroupPolicy < ApplicationPolicy
       where(user: user, app_group_roles: { name: [:owner] }).count > 0
   end
 
-  def allow_action?
-    manage_access?
-  end
-
-  def allow_upgrade?
+  def allow_see_apps?
     return true if get_user_groups
 
-    AppGroupUser.
-      joins(:role).
-      where(user: user, app_group_roles: { name: [:admin, :owner] }).
-      count > 0
-  end
-
-  def allow_see_apps?
-    allow_upgrade?
+    user.app_groups.where(id: record.id).count > 0
   end
 
   class Scope < Scope

--- a/app/policies/app_group_policy.rb
+++ b/app/policies/app_group_policy.rb
@@ -1,4 +1,13 @@
 class AppGroupPolicy < ApplicationPolicy
+  def new?
+    return true if get_user_groups
+    false
+  end
+
+  def create?
+    new?
+  end
+
   def show?
     return true if get_user_groups
     return true if record.created_by == user
@@ -28,6 +37,10 @@ class AppGroupPolicy < ApplicationPolicy
       joins(:role).
       where(user: user, app_group_roles: { name: [:admin, :owner] }).
       count > 0
+  end
+
+  def allow_see_apps?
+    allow_upgrade?
   end
 
   class Scope < Scope

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -50,4 +50,15 @@ class ApplicationPolicy
       scope
     end
   end
+
+  private
+
+  def get_user_groups
+    if Figaro.env.enable_cas_integration == 'true'
+      gate_groups = GateWrapper.new(user).check_user_groups.symbolize_keys[:groups] || []
+      return true if Group.where(name: gate_groups).count > 0
+    else
+      return true if user.groups.count > 0
+    end
+  end
 end

--- a/app/policies/barito_app_policy.rb
+++ b/app/policies/barito_app_policy.rb
@@ -11,15 +11,4 @@ class BaritoAppPolicy < ApplicationPolicy
   def delete?
     create?
   end
-
-  private
-
-  def get_user_groups
-    if Figaro.env.enable_cas_integration == 'true'
-      gate_groups = GateWrapper.new(user).check_user_groups.symbolize_keys[:groups] || []
-      return true if Group.where(name: gate_groups).count > 0
-    else
-      return true if user.groups.count > 0
-    end
-  end
 end

--- a/app/policies/barito_app_policy.rb
+++ b/app/policies/barito_app_policy.rb
@@ -1,7 +1,6 @@
 class BaritoAppPolicy < ApplicationPolicy
   def create?
     return true if get_user_groups
-    return true if record.app_group.try(:created_by) == user
 
     AppGroupUser.
       joins(:role).

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -6,8 +6,6 @@ class GroupPolicy < ApplicationPolicy
     else
       return true if user.groups.count > 0
     end
-
-    GroupUser.where(user: user).count > 0
   end
 
   def show?

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -1,11 +1,7 @@
 class GroupPolicy < ApplicationPolicy
   def index?
-    if Figaro.env.enable_cas_integration == 'true'
-      gate_groups = GateWrapper.new(user).check_user_groups.symbolize_keys[:groups] || []
-      return Group.all if Group.where(name: gate_groups).count > 0
-    else
-      return true if user.groups.count > 0
-    end
+    return true if get_user_groups
+    false
   end
 
   def show?

--- a/app/policies/infrastructure_policy.rb
+++ b/app/policies/infrastructure_policy.rb
@@ -1,9 +1,6 @@
 class InfrastructurePolicy < ApplicationPolicy
   def show?
     return true if get_user_groups
-
-    app_group_ids = AppGroupUser.where(user: user).pluck(:app_group_id)
-    app_group_ids.include?(record.id)
   end
 
   def retry?

--- a/app/policies/infrastructure_policy.rb
+++ b/app/policies/infrastructure_policy.rb
@@ -1,0 +1,12 @@
+class InfrastructurePolicy < ApplicationPolicy
+  def show?
+    return true if get_user_groups
+
+    app_group_ids = AppGroupUser.where(user: user).pluck(:app_group_id)
+    app_group_ids.include?(record.id)
+  end
+
+  def retry?
+    show?
+  end
+end

--- a/app/views/app_groups/_applications.html.slim
+++ b/app/views/app_groups/_applications.html.slim
@@ -1,0 +1,40 @@
+h4.mb-3 All Applications
+
+= form_for(app, url: apps_path) do |f|
+  = f.hidden_field :app_group_id, value: app_group.id
+  table.table.table-bordered
+    thead.thead-dark
+      tr
+        th.text-center Name
+        th.text-center Topic Name
+        th.text-center Secret Key
+        th.text-center Max TPS
+        th.text-center Status
+        th.text-center Log Count
+        th.text-center Created At
+        th.text-center Actions
+    tbody
+      - apps.each do |barito_app|
+        tr
+          td.text-center= barito_app.name
+          td.text-center= barito_app.topic_name
+          td.text-center= barito_app.secret_key
+          td.text-center= barito_app.max_tps
+          td.text-center= barito_app.status
+          td.text-center= barito_app.log_count
+          td.text-center= barito_app.created_at
+          td.text-center
+            - if allow_delete
+              = link_to "Delete", app_path(barito_app), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'
+
+      - if allow_add
+        tr
+          td.text-center= f.text_field :name
+          td.text-center= f.text_field :topic_name
+          td.text-center
+          td.text-center= f.text_field :max_tps
+          td.text-center
+          td.text-center
+          td.text-center
+          td.text-center
+            = f.submit 'Create', class: 'btn btn-primary'

--- a/app/views/app_groups/index.html.slim
+++ b/app/views/app_groups/index.html.slim
@@ -5,11 +5,13 @@
     | Looks like you have no access to any application groups right now
     br
     | Click the button below to get started
-  = link_to 'New Application Group', new_app_group_path, class: 'btn btn-primary'
+  - if @allow_create_app_group
+    = link_to 'New Application Group', new_app_group_path, class: 'btn btn-primary'
 - else
   h3.mb-3 All Application Groups
 
-  p= link_to 'New Application Group', new_app_group_path, class: 'btn btn-primary'
+  - if @allow_create_app_group
+    p= link_to 'New Application Group', new_app_group_path, class: 'btn btn-primary'
   table.table.table-bordered
     thead.thead-dark
       tr

--- a/app/views/app_groups/manage_access.html.slim
+++ b/app/views/app_groups/manage_access.html.slim
@@ -15,7 +15,7 @@
       - @app_group_users.each do |member|
         li.list-group-item
           .row.no-gutters
-            .col-10= member.username + ' - ' + member.email
+            .col-10= member.email || member.username
             .col-2.text-right= link_to 'Delete', app_group_user_path(user_id: member.user_id, app_group_id: @app_group.id), class: 'btn btn-danger', data: { method: :delete }
           .row.no-gutters
             .col-12

--- a/app/views/app_groups/show.html.slim
+++ b/app/views/app_groups/show.html.slim
@@ -24,49 +24,13 @@ p
 - if @allow_upgrade
   = link_to 'Upgrade', '#', class: 'btn btn-primary mr-2'
 - if @allow_action
-  = link_to 'Manage Access', manage_access_app_group_path(@app_group), class: 'btn btn-primary'
+  = link_to 'Manage Access', manage_access_app_group_path(@app_group), class: 'btn btn-primary mr-2'
   = link_to 'Show Infrastructure', infrastructure_path(@app_group.infrastructure.id), class: 'btn btn-warning'
 
 br
 br
 
-h4.mb-3 All Applications
-
-= form_for(@app, url: apps_path) do |f|
-  = f.hidden_field :app_group_id, value: @app_group.id
-  table.table.table-bordered
-    thead.thead-dark
-      tr
-        th.text-center Name
-        th.text-center Topic Name
-        th.text-center Secret Key
-        th.text-center Max TPS
-        th.text-center Status
-        th.text-center Log Count
-        th.text-center Created At
-        th.text-center Actions
-    tbody
-      - @apps.each do |barito_app|
-        tr
-          td.text-center= barito_app.name
-          td.text-center= barito_app.topic_name
-          td.text-center= barito_app.secret_key
-          td.text-center= barito_app.max_tps
-          td.text-center= barito_app.status
-          td.text-center= barito_app.log_count
-          td.text-center= barito_app.created_at
-          td.text-center
-            - if @allow_delete_barito_app
-              = link_to "Delete", app_path(barito_app), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'
-
-      - if @allow_add_barito_app
-        tr
-          td.text-center= f.text_field :name
-          td.text-center= f.text_field :topic_name
-          td.text-center
-          td.text-center= f.text_field :max_tps
-          td.text-center
-          td.text-center
-          td.text-center
-          td.text-center
-            = f.submit 'Create', class: 'btn btn-primary'
+- if @allow_see_apps
+  = render 'app_groups/applications', app: @app, app_group: @app_group, apps: @apps,
+                                      allow_delete: @allow_delete_barito_app,
+                                      allow_add: @allow_add_barito_app

--- a/app/views/app_groups/show.html.slim
+++ b/app/views/app_groups/show.html.slim
@@ -21,10 +21,9 @@ p
   br
 
 = link_to 'Open Kibana', '#', class: 'btn btn-primary mr-2'
-- if @allow_upgrade
-  = link_to 'Upgrade', '#', class: 'btn btn-primary mr-2'
-- if @allow_action
+- if @allow_manage_access
   = link_to 'Manage Access', manage_access_app_group_path(@app_group), class: 'btn btn-primary mr-2'
+- if @allow_see_infrastructure
   = link_to 'Show Infrastructure', infrastructure_path(@app_group.infrastructure.id), class: 'btn btn-warning'
 
 br

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -20,7 +20,7 @@ html
       #bm-main-navbar.collapse.navbar-collapse
         ul.navbar-nav.ml-auto
           form.form-inline.mt-2.mt-md-0
-            - if user_signed_in?
+            - if user_signed_in? && allow_manage_groups?
               = link_to 'Groups', groups_path, class: 'btn btn-outline-primary ml-sm-2'
           - if user_signed_in?
             li.nav-item

--- a/bin/setup_chrome
+++ b/bin/setup_chrome
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Install Chrome
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+apt-get update -yqqq
+apt-get install -y google-chrome-stable > /dev/null 2>&1
+sed -i 's/"$@"/--no-sandbox "$@"/g' /opt/google/chrome/google-chrome
+
+# Install chromedriver
+wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip
+unzip /tmp/chromedriver.zip chromedriver -d /usr/bin/
+rm /tmp/chromedriver.zip
+chmod ugo+rx /usr/bin/chromedriver

--- a/db/migrate/20180806050132_remove_created_by_id_in_app_groups.rb
+++ b/db/migrate/20180806050132_remove_created_by_id_in_app_groups.rb
@@ -1,0 +1,5 @@
+class RemoveCreatedByIdInAppGroups < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :app_groups, :created_by_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_17_040929) do
+ActiveRecord::Schema.define(version: 2018_08_06_050132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,9 +37,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_040929) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "created_by_id"
     t.datetime "deleted_at"
-    t.index ["created_by_id"], name: "index_app_groups_on_created_by_id"
   end
 
   create_table "barito_apps", force: :cascade do |t|
@@ -113,5 +111,4 @@ ActiveRecord::Schema.define(version: 2018_07_17_040929) do
     t.index ["username"], name: "index_users_on_username", unique: true, where: "((username IS NOT NULL) AND ((username)::text <> ''::text))"
   end
 
-  add_foreign_key "app_groups", "users", column: "created_by_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,6 @@
-Group.create(name: 'barito-superadmin')
+group = Group.create(name: 'barito-superadmin')
+user = User.create(email: 'superadmin@barito.com', username: 'superadmin', password: '123456', password_confirmation: '123456')
+GroupUser.create(user: user, group: group)
 
 ['admin', 'owner', 'member'].each do |role|
   AppGroupRole.create(name: role)

--- a/spec/factories/app_groups.rb
+++ b/spec/factories/app_groups.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :app_group do
-    association :created_by, factory: :user
     sequence(:name) { |n| "#{Faker::Cat.name} #{n}" }
   end
 end

--- a/spec/features/app_group_management/create_app_group_spec.rb
+++ b/spec/features/app_group_management/create_app_group_spec.rb
@@ -4,29 +4,35 @@ RSpec.feature 'Application Group Management', type: :feature do
   let(:user_a) { create(:user) }
   let(:user_b) { create(:user) }
 
-  before(:each) do
-    @app_group_a = create(:app_group, created_by: user_a)
-    @app_group_b = create(:app_group, created_by: user_b)
-
-    [@app_group_a, @app_group_b].each { |app_group| create(:infrastructure, app_group: app_group) }
-  end
-
   describe 'Create applications group' do
-    scenario 'User can create new application group' do
-      set_check_user_groups({ 'groups': [] })
-      login_as user_a
-      prep_app_group = build(:app_group)
+    context 'As Superadmin' do
+      scenario 'User can create new application group' do
+        set_check_user_groups({ 'groups': ['barito-superadmin'] })
+        login_as user_a
+        create(:group, name: 'barito-superadmin')
+        prep_app_group = build(:app_group)
 
-      visit root_path
+        visit root_path
 
-      click_link 'New Application Group'
-      within('#app_group_form') do
-        fill_in 'app_group_name', with: prep_app_group.name
-        select TPS_CONFIG.keys[0], from: 'app_group[capacity]'
+        click_link 'New Application Group'
+        within('#app_group_form') do
+          fill_in 'app_group_name', with: prep_app_group.name
+          select TPS_CONFIG.keys[0], from: 'app_group[capacity]'
+        end
+
+        click_button 'Submit'
+        expect(page).to have_content(prep_app_group.name)
       end
+    end
 
-      click_button 'Submit'
-      expect(page).to have_content(prep_app_group.name)
+    context 'As other User' do
+      scenario 'User cannot create new application group' do
+        set_check_user_groups({ 'groups' => [] })
+        login_as user_a
+        visit root_path
+
+        expect(page).not_to have_content('New Application Group')
+      end
     end
   end
 end

--- a/spec/features/app_group_management/do_actions_spec.rb
+++ b/spec/features/app_group_management/do_actions_spec.rb
@@ -7,16 +7,18 @@ RSpec.feature 'Application Group Management', type: :feature do
   before(:each) do
     set_check_user_groups({ 'groups' => [] })
 
-    @app_group_a = create(:app_group, created_by: user_a)
-    @app_group_b = create(:app_group, created_by: user_b)
+    @app_group_a = create(:app_group)
+    @app_group_b = create(:app_group)
 
     [@app_group_a, @app_group_b].each { |app_group| create(:infrastructure, app_group: app_group) }
   end
 
   describe 'Do Updrade/Manage Access and Create/Delete Barito App' do
-    context 'As Owner' do
-      scenario 'User can do those actions' do
+    context 'As Superadmin' do
+      scenario 'User is allowed to do those actions' do
+        set_check_user_groups({ 'groups': ['barito-superadmin'] })
         login_as user_a
+        create(:group, name: 'barito-superadmin')
 
         visit root_path
         click_link @app_group_a.name
@@ -28,7 +30,37 @@ RSpec.feature 'Application Group Management', type: :feature do
     end
 
     context 'As Authorized User based on Role' do
-      scenario 'User with role member cannot do any actions' do
+      scenario 'User with role "owner" can do those actions' do
+        create(:app_group_user, app_group: @app_group_a, role: create(:app_group_role, :owner), user: user_b)
+
+        login_as user_b
+        visit root_path
+
+        click_link @app_group_a.name
+
+        expect(page).to have_current_path(app_group_path(@app_group_a))
+        expect(page).to have_css('input[name="commit"][value="Create"]')
+        expect(page).to have_content('Manage Access')
+        expect(page).to have_content('Upgrade')
+        
+      end
+
+      scenario 'User with role "admin" can do those actions' do
+        create(:app_group_user, app_group: @app_group_a, role: create(:app_group_role, :admin), user: user_b)
+
+        login_as user_b
+        visit root_path
+
+        click_link @app_group_a.name
+
+        expect(page).to have_current_path(app_group_path(@app_group_a))
+        expect(page).to have_css('input[name="commit"][value="Create"]')
+        expect(page).not_to have_content('Manage Access')
+        expect(page).to have_content('Upgrade')
+        
+      end
+
+      scenario 'User with role "member" cannot do any actions' do
         create(:app_group_user, app_group: @app_group_a, role: create(:app_group_role), user: user_b)
 
         login_as user_b

--- a/spec/features/app_group_management/do_actions_spec.rb
+++ b/spec/features/app_group_management/do_actions_spec.rb
@@ -25,7 +25,6 @@ RSpec.feature 'Application Group Management', type: :feature do
 
         expect(page).to have_content('Create')
         expect(page).to have_content('Manage Access')
-        expect(page).to have_content('Upgrade')
       end
     end
 
@@ -41,8 +40,6 @@ RSpec.feature 'Application Group Management', type: :feature do
         expect(page).to have_current_path(app_group_path(@app_group_a))
         expect(page).to have_css('input[name="commit"][value="Create"]')
         expect(page).to have_content('Manage Access')
-        expect(page).to have_content('Upgrade')
-        
       end
 
       scenario 'User with role "admin" can do those actions' do
@@ -56,8 +53,6 @@ RSpec.feature 'Application Group Management', type: :feature do
         expect(page).to have_current_path(app_group_path(@app_group_a))
         expect(page).to have_css('input[name="commit"][value="Create"]')
         expect(page).not_to have_content('Manage Access')
-        expect(page).to have_content('Upgrade')
-        
       end
 
       scenario 'User with role "member" cannot do any actions' do
@@ -71,7 +66,6 @@ RSpec.feature 'Application Group Management', type: :feature do
         expect(page).to have_current_path(app_group_path(@app_group_a))
         expect(page).not_to have_css('input[name="commit"][value="Create"]')
         expect(page).not_to have_content('Manage Access')
-        expect(page).not_to have_content('Upgrade')
       end
     end
   end

--- a/spec/features/app_group_management/manage_access_spec.rb
+++ b/spec/features/app_group_management/manage_access_spec.rb
@@ -8,14 +8,14 @@ RSpec.feature 'Application Group Management', type: :feature do
   before(:each) do
     set_check_user_groups({ 'groups' => [] })
 
-    @app_group_a = create(:app_group, created_by: user_a)
-    @app_group_b = create(:app_group, created_by: user_b)
+    @app_group_a = create(:app_group)
+    @app_group_b = create(:app_group)
 
     [@app_group_a, @app_group_b].each { |app_group| create(:infrastructure, app_group: app_group) }
   end
 
   describe 'Managing Access', js: true do
-    context 'As Owner or Superadmin' do
+    context 'As Superadmin' do
       scenario 'User can add members to app group' do
         set_check_user_groups({ 'groups' => ['barito-superadmin'] })
         create(:group, name: 'barito-superadmin')
@@ -26,16 +26,16 @@ RSpec.feature 'Application Group Management', type: :feature do
         click_link @app_group_a.name
 
         click_link 'Manage Access'
-        set_select2_option(selector: '#assign_member_user_id', text: user_b.username, value: user_b.id)
+        set_select2_option(selector: '#assign_member_user_id', text: user_b.email, value: user_b.id)
         find('form#new_app_group_user input[value="Add"]').click
 
-        expect(page).to have_content("#{user_b.username} - #{user_b.email}")
+        expect(page).to have_content(user_b.email)
         expect(page).to have_css("a[href='#{app_group_user_path(user_id: user_b.id, app_group_id: @app_group_a.id)}']")
       end
     end
 
     context 'As Authorized User based on Role' do
-      scenario 'User with role admin cannot manage access but can add/delete barito app' do
+      scenario 'User with role "admin" cannot manage access but can add/delete barito app' do
         create(:app_group_user, app_group: @app_group_a, role: create(:app_group_role, :admin), user: user_b)
 
         login_as user_b
@@ -47,7 +47,7 @@ RSpec.feature 'Application Group Management', type: :feature do
         expect(page).to have_css("form#new_barito_app")
       end
 
-      scenario 'User with role "owner" can do just like owner/superadmin' do
+      scenario 'User with role "owner" can do just like superadmin' do
         create(:app_group_user, app_group: @app_group_a, role: create(:app_group_role, :owner), user: user_b)
 
         login_as user_b

--- a/spec/features/app_group_management/view_list_spec.rb
+++ b/spec/features/app_group_management/view_list_spec.rb
@@ -7,20 +7,22 @@ RSpec.feature 'Application Group Management', type: :feature do
   before(:each) do
     set_check_user_groups({ 'groups' => [] })
 
-    @app_group_a = create(:app_group, created_by: user_a)
-    @app_group_b = create(:app_group, created_by: user_b)
+    @app_group_a = create(:app_group)
+    @app_group_b = create(:app_group)
 
     [@app_group_a, @app_group_b].each { |app_group| create(:infrastructure, app_group: app_group) }
   end
 
   describe 'View applications group lists' do
-    context 'As Owner/Superadmin' do
+    context 'As Superadmin' do
       scenario 'User can only see app group that they created' do
+        set_check_user_groups({ 'groups' => 'barito-superadmin' })
+        create(:group, name: 'barito-superadmin')
         login_as user_a
 
         visit root_path
         expect(page).to have_content(@app_group_a.name)
-        expect(page).not_to have_content(@app_group_b.name)
+        expect(page).to have_content(@app_group_b.name)
       end
     end
 
@@ -32,7 +34,7 @@ RSpec.feature 'Application Group Management', type: :feature do
 
         visit root_path
         expect(page).to have_content(@app_group_a.name)
-        expect(page).to have_content(@app_group_b.name)
+        expect(page).not_to have_content(@app_group_b.name)
       end
     end
   end

--- a/spec/features/barito_app_management/create_barito_app_spec.rb
+++ b/spec/features/barito_app_management/create_barito_app_spec.rb
@@ -8,12 +8,11 @@ RSpec.feature 'Barito App Management', type: :feature do
   describe 'Create new barito app' do
     before(:each) do
       set_check_user_groups({ 'groups' => [] })
-
-      @app_group = create(:app_group, created_by: user_a)
+      @app_group = create(:app_group)
       create(:infrastructure, app_group: @app_group)
     end
 
-    context 'As Owner/ As Superadmin' do
+    context 'As Superadmin' do
       scenario 'User can create/add barito app' do
         set_check_user_groups({ 'groups' => ['barito-superadmin'] })
         create(:group, name: 'barito-superadmin')
@@ -34,7 +33,7 @@ RSpec.feature 'Barito App Management', type: :feature do
     end
 
     context 'As Authorized User based on Role' do
-      scenario 'User with owner role can create barito app' do
+      scenario 'User with "owner" or "admin" role can create barito app' do
         create(:app_group_user, app_group: @app_group, role: create(:app_group_role, :owner), user: user_b)
 
         login_as user_b
@@ -52,7 +51,7 @@ RSpec.feature 'Barito App Management', type: :feature do
         expect(page).to have_content(barito_app.name)
       end
 
-      scenario 'User with member role cannot create barito app' do
+      scenario 'User with "member" role cannot create barito app' do
         create(:app_group_user, app_group: @app_group, role: create(:app_group_role), user: user_b)
 
         login_as user_b

--- a/spec/features/barito_app_management/delete_barito_app_spec.rb
+++ b/spec/features/barito_app_management/delete_barito_app_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'Barito App Management', type: :feature do
         login_as user_b
         visit app_group_path(@app_group)
 
-        expect(page).not_to have_content(@barito_app.name)
+        expect(page).to have_content(@barito_app.name)
         expect(page).not_to have_css("a[href='#{app_path(@barito_app)}'][data-method='delete']")
       end
     end

--- a/spec/features/barito_app_management/delete_barito_app_spec.rb
+++ b/spec/features/barito_app_management/delete_barito_app_spec.rb
@@ -9,12 +9,12 @@ RSpec.feature 'Barito App Management', type: :feature do
     before(:each) do
       set_check_user_groups({ 'groups' => [] })
 
-      @app_group = create(:app_group, created_by: user_a)
+      @app_group = create(:app_group)
       create(:infrastructure, app_group: @app_group)
       @barito_app = create(:barito_app, app_group: @app_group)
     end
 
-    context 'As Owner/As Superadmin' do
+    context 'As Superadmin' do
       scenario 'User can delete existing barito app' do
         set_check_user_groups({ 'groups' => ['barito-superadmin'] })
         create(:group, name: 'barito-superadmin')
@@ -29,7 +29,7 @@ RSpec.feature 'Barito App Management', type: :feature do
     end
 
     context 'As Authorized User based on Role' do
-      scenario 'User with owner/admin role can delete existing barito app' do
+      scenario 'User with "owner" or "admin" role can delete existing barito app' do
         create(:app_group_user, app_group: @app_group, role: create(:app_group_role, :admin), user: user_b)
 
         login_as user_b
@@ -41,13 +41,13 @@ RSpec.feature 'Barito App Management', type: :feature do
         expect(page).not_to have_content(@barito_app.name)
       end
 
-      scenario 'User with member role cannot delete existing barito app' do
+      scenario 'User with "member" role cannot delete existing barito app' do
         create(:app_group_user, app_group: @app_group, role: create(:app_group_role), user: user_b)
 
         login_as user_b
         visit app_group_path(@app_group)
 
-        expect(page).to have_content(@barito_app.name)
+        expect(page).not_to have_content(@barito_app.name)
         expect(page).not_to have_css("a[href='#{app_path(@barito_app)}'][data-method='delete']")
       end
     end

--- a/spec/features/barito_app_management/view_list_spec.rb
+++ b/spec/features/barito_app_management/view_list_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Barito App Management', type: :feature do
     end
 
     context 'As Authorized User based on Role' do
-      scenario 'User with "owner" or "admin" role can see the barito app list' do
+      scenario 'User with "owner" or "admin" or "member" role can see the barito app list' do
         create(:app_group_user, app_group: @app_group, role: create(:app_group_role, :admin), user: user_b)
         login_as user_b
 
@@ -35,16 +35,16 @@ RSpec.feature 'Barito App Management', type: :feature do
         click_link @app_group.name
 
         expect(page).to have_content(@barito_app.name)
-      end
 
-      scenario 'User registered as member in app group can see the barito app list' do
-        create(:app_group_user, app_group: @app_group, role: create(:app_group_role), user: user_b)
-        login_as user_b
+        logout
+
+        create(:app_group_user, app_group: @app_group, role: create(:app_group_role), user: user_a)
+        login_as user_a
 
         visit root_path
         click_link @app_group.name
 
-        expect(page).not_to have_content(@barito_app.name)
+        expect(page).to have_content(@barito_app.name)
       end
     end
   end

--- a/spec/features/barito_app_management/view_list_spec.rb
+++ b/spec/features/barito_app_management/view_list_spec.rb
@@ -8,14 +8,16 @@ RSpec.feature 'Barito App Management', type: :feature do
     before(:each) do
       set_check_user_groups({ 'groups' => [] })
 
-      @app_group = create(:app_group, created_by: user_a)
+      @app_group = create(:app_group)
       create(:infrastructure, app_group: @app_group)
       @barito_app = create(:barito_app, app_group: @app_group)
     end
 
-    context 'As Owner/ As Superadmin' do
+    context 'As Superadmin' do
       scenario 'User can see barito app lists in application group page' do
+        set_check_user_groups({ 'groups': ['barito-superadmin'] })
         login_as user_a
+        create(:group, name: 'barito-superadmin')
         visit root_path
 
         click_link @app_group.name
@@ -25,6 +27,16 @@ RSpec.feature 'Barito App Management', type: :feature do
     end
 
     context 'As Authorized User based on Role' do
+      scenario 'User with "owner" or "admin" role can see the barito app list' do
+        create(:app_group_user, app_group: @app_group, role: create(:app_group_role, :admin), user: user_b)
+        login_as user_b
+
+        visit root_path
+        click_link @app_group.name
+
+        expect(page).to have_content(@barito_app.name)
+      end
+
       scenario 'User registered as member in app group can see the barito app list' do
         create(:app_group_user, app_group: @app_group, role: create(:app_group_role), user: user_b)
         login_as user_b
@@ -32,7 +44,7 @@ RSpec.feature 'Barito App Management', type: :feature do
         visit root_path
         click_link @app_group.name
 
-        expect(page).to have_content(@barito_app.name)
+        expect(page).not_to have_content(@barito_app.name)
       end
     end
   end

--- a/spec/features/infrastructure_management/show_spec.rb
+++ b/spec/features/infrastructure_management/show_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Infrastructure Management', type: :feature do
   let(:user) { create(:user) }
 
   before(:each) do
+    set_check_user_groups({ 'groups' => [] })
     @infrastructure = create(:infrastructure)
     @infrastructure_components = []
     3.times.each do
@@ -12,8 +13,10 @@ RSpec.feature 'Infrastructure Management', type: :feature do
   end
 
   describe 'View infrastructure details' do
-    context 'As Owner/Superadmin' do
-      it 'shows' do
+    context 'As Superadmin' do
+      scenario 'User allowed to see infrastructure details' do
+        set_check_user_groups({ 'groups' => 'barito-superadmin' })
+        create(:group, name: 'barito-superadmin')
         login_as user
 
         visit infrastructure_path(@infrastructure.id)

--- a/spec/features/infrastructure_management/show_spec.rb
+++ b/spec/features/infrastructure_management/show_spec.rb
@@ -26,5 +26,16 @@ RSpec.feature 'Infrastructure Management', type: :feature do
         end
       end
     end
+
+    context 'As other users' do
+      scenario 'User is not allowed to see infrastructure details' do
+        login_as user
+
+        visit infrastructure_path(@infrastructure.id)
+
+        expect(page).to have_current_path(root_path)
+        expect(page).to have_content('You are not authorized to perform this action')
+      end
+    end
   end
 end

--- a/spec/models/app_group_spec.rb
+++ b/spec/models/app_group_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe AppGroup, type: :model do
       app_group, infrastructure = AppGroup.setup(
         Rails.env,
         name: app_group_props.name,
-        capacity: 'small',
-        created_by_id: app_group_props.created_by_id
+        capacity: 'small'
       )
       expect(app_group.persisted?).to eq(true)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,8 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+Capybara.server = :puma, { Silent: true }
+
 Capybara.register_driver :custom_headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(headless disable-gpu no-sandbox) }
@@ -50,37 +52,15 @@ RSpec.configure do |config|
   config.include GateWrapperHelper
   config.include AppViewHelper
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
   config.use_transactional_fixtures = true
-
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
-
-  # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
+
   config.before(:suite) do
     ENV['ENABLE_CAS_INTEGRATION'] = 'true'
 
-    WebMock.disable_net_connect!(:allow_localhost => true)
+    WebMock.disable_net_connect!(allow: ['localhost', '127.0.0.1', /selenium/])
     Sidekiq::Testing.fake!
     DatabaseCleaner.clean_with(:truncation)
   end


### PR DESCRIPTION
- Remove `created_by_id` in `app_groups`. So no longer `owner` status from `app_groups`, but the `owner` is only set by `app_group_roles`

- Only barito-superadmin that allowed to create new AppGroup, manage Infrastructure, and managin Groups. The rest is only allowed to manage the AppGroup but they ability is controller based on AppGroupRole.
- User with Member role can: open AppGroup page, see the list of apps installed in that AppGroup, and open Kibana of that AppGroup.
- User with Admin role can: same with User with role Member, but with additional can add or delete apps installed in that AppGroup.
- User with Admin role can: same with User with role Admin, but with additional can manage access to that AppGroup.
