### PR TITLE
Fix bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,8 +15,6 @@ sudo apt-get install -y ruby-full
 echo "Install chef"
 wget --quiet https://packages.chef.io/files/stable/chefdk/3.9.0/ubuntu/18.04/chefdk_3.9.0-1_amd64.deb
 sudo dpkg -i chefdk_3.9.0-1_amd64.deb
-echo 'eval "$(chef shell-init bash)"' >> ~/.profile
-source ~/.profile
 
 echo "Creating private key"
 yes "" | ssh-keygen -t rsa

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,7 @@ echo "install ruby"
 sudo apt-get install -y ruby-full
 
 echo "Install chef"
-wget https://packages.chef.io/files/stable/chefdk/3.9.0/ubuntu/18.04/chefdk_3.9.0-1_amd64.deb
+wget --quiet https://packages.chef.io/files/stable/chefdk/3.9.0/ubuntu/18.04/chefdk_3.9.0-1_amd64.deb
 sudo dpkg -i chefdk_3.9.0-1_amd64.deb
 echo 'eval "$(chef shell-init bash)"' >> ~/.profile
 source ~/.profile
@@ -156,5 +156,5 @@ current_profile = "default"
 EOF
 sudo chown vagrant:vagrant /home/vagrant/.pfi/config
 
-sudo wget -O /usr/local/bin/pfi https://github.com/pathfinder-cm/pfi/releases/download/0.1.0/pfi-linux
+sudo wget --quiet -O /usr/local/bin/pfi https://github.com/pathfinder-cm/pfi/releases/download/0.1.0/pfi-linux
 sudo chmod +x /usr/local/bin/pfi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -123,6 +123,7 @@ sudo cat > bootstrap.json << EOF
 }
 EOF
 
+sudo gem install bundler -v 2.0.1
 sudo chef-solo -c /opt/baritolog/solo.rb -j /opt/baritolog/bootstrap.json
 
 echo "Adding private key into barito_market config"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -134,12 +134,12 @@ sudo chmod 600 barito
 
 echo "Running initial seed barito-market"
 cd /opt/barito_market/BaritoMarket
-RAILS_ENV=production rake db:seed
+RAILS_ENV=production bundle exec rake db:seed
 
 echo "Running initial seed pathfinder-mono"
 cd /opt/pathfinder-mono/pathfinder-mono
 sudo chmod 644 ./.env
-RAILS_ENV=production rake db:seed
+RAILS_ENV=production bundle exec rake db:seed
 
 echo "Installing PFI"
 sudo mkdir /home/vagrant/.pfi -p


### PR DESCRIPTION
There are four changes in this pull request.

- Make `wget` silent so it doesn't spam the log.
- Use `bundler` 2.0.1 to fix bundler version incompatibility error.
- Use `bundler exec` to run `rake db:seed`.
- Remove the `chef shell-init` routine since it's not being used by the `chef-solo` itself (`chef-solo` is called using `sudo` which cleans the environment variable) and broke the migration routine because it uses Chef's Ruby, not the system-wide one.