### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ addons:
 services:
   - postgresql
 before_script:
-  - wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip
-  - unzip /tmp/chromedriver.zip chromedriver -d /usr/bin/
-  - rm /tmp/chromedriver.zip
-  - chmod ugo+rx /usr/bin/chromedriver
-  - export CHROME_BIN=chromium-browser
   - cp config/application.yml.example config/application.yml
   - cp config/database.yml.example config/database.yml
   - cp config/tps_config.yml.example config/tps_config.yml

--- a/spec/lib/chef_helper/barito_flow_consumer_role_attributes_generator_spec.rb
+++ b/spec/lib/chef_helper/barito_flow_consumer_role_attributes_generator_spec.rb
@@ -4,41 +4,29 @@ module ChefHelper
   RSpec.describe BaritoFlowConsumerRoleAttributesGenerator do
     before(:each) do
       @infrastructure = create(:infrastructure, cluster_name: 'test')
-      @consul_component = create(:infrastructure_component, 
+      @consul_component = create(:infrastructure_component,
         infrastructure: @infrastructure,
         hostname:       'test-consul-01',
         component_type: 'consul',
         ipaddress:      '127.0.0.1'
       )
-      @consumer_component = create(:infrastructure_component, 
+      @consumer_component = create(:infrastructure_component,
         infrastructure: @infrastructure,
         hostname:       'test-barito-flow-consumer-01',
         component_type: 'barito-flow-consumer',
         ipaddress:      '127.0.0.2'
       )
-      @kafka_component_1 = create(:infrastructure_component, 
+      @kafka_component_1 = create(:infrastructure_component,
         infrastructure: @infrastructure,
         hostname:       'test-kafka-01',
         component_type: 'kafka',
         ipaddress:      '127.0.0.15'
       )
-      @kafka_component_2 = create(:infrastructure_component, 
-        infrastructure: @infrastructure,
-        hostname:       'test-kafka-02',
-        component_type: 'kafka',
-        ipaddress:      '127.0.0.16'
-      )
-      @elastic_component_1 = create(:infrastructure_component, 
+      @elastic_component_1 = create(:infrastructure_component,
         infrastructure: @infrastructure,
         hostname:       'test-elasticsearch-01',
         component_type: 'elasticsearch',
         ipaddress:      '127.0.0.17'
-      )
-      @elastic_component_2 = create(:infrastructure_component, 
-        infrastructure: @infrastructure,
-        hostname:       'test-elasticsearch-02',
-        component_type: 'elasticsearch',
-        ipaddress:      '127.0.0.18'
       )
     end
 
@@ -48,7 +36,7 @@ module ChefHelper
           @consumer_component,
           @infrastructure.infrastructure_components
         )
-        
+
         attrs = consumer_attributes.generate
 
         expect(attrs).to eq({
@@ -65,12 +53,12 @@ module ChefHelper
                 "version"=>"v0.11.8",
                 "env_vars"=>{
                   "BARITO_CONSUL_URL"=>"http://#{@consul_component.ipaddress}:8500",
-                  "BARITO_CONSUL_KAFKA_NAME"=>"kafka", 
+                  "BARITO_CONSUL_KAFKA_NAME"=>"kafka",
                   "BARITO_CONSUL_ELASTICSEARCH_NAME"=>"elasticsearch",
-                  "BARITO_KAFKA_BROKERS"=>"#{@kafka_component_2.ipaddress}:9092,#{@kafka_component_1.ipaddress}:9092", 
-                  "BARITO_KAFKA_GROUP_ID"=>"barito-group", 
-                  "BARITO_KAFKA_CONSUMER_TOPICS"=>"barito-log", 
-                  "BARITO_ELASTICSEARCH_URLS"=>"http://#{@elastic_component_2.ipaddress}:9200,http://#{@elastic_component_1.ipaddress}:9200", 
+                  "BARITO_KAFKA_BROKERS"=>"#{@kafka_component_1.ipaddress}:9092",
+                  "BARITO_KAFKA_GROUP_ID"=>"barito-group",
+                  "BARITO_KAFKA_CONSUMER_TOPICS"=>"barito-log",
+                  "BARITO_ELASTICSEARCH_URLS"=>"http://#{@elastic_component_1.ipaddress}:9200",
                   "BARITO_PUSH_METRIC_URL"=>"#{Figaro.env.market_end_point}/api/increase_log_count"
                 }
               }
@@ -81,4 +69,3 @@ module ChefHelper
     end
   end
 end
-

--- a/spec/lib/chef_helper/barito_flow_producer_role_attributes_generator_spec.rb
+++ b/spec/lib/chef_helper/barito_flow_producer_role_attributes_generator_spec.rb
@@ -4,29 +4,23 @@ module ChefHelper
   RSpec.describe BaritoFlowProducerRoleAttributesGenerator do
     before(:each) do
       @infrastructure = create(:infrastructure, cluster_name: 'test')
-      @consul_component = create(:infrastructure_component, 
+      @consul_component = create(:infrastructure_component,
         infrastructure: @infrastructure,
         hostname:       'test-consul-01',
         component_type: 'consul',
         ipaddress:      '127.0.0.1'
       )
-      @producer_component = create(:infrastructure_component, 
+      @producer_component = create(:infrastructure_component,
         infrastructure: @infrastructure,
         hostname:       'test-barito-flow-producer-01',
         component_type: 'barito-flow-producer',
         ipaddress:      '127.0.0.2'
       )
-      @kafka_component_1 = create(:infrastructure_component, 
+      @kafka_component_1 = create(:infrastructure_component,
         infrastructure: @infrastructure,
         hostname:       'test-kafka-01',
         component_type: 'kafka',
         ipaddress:      '127.0.0.15'
-      )
-      @kafka_component_2 = create(:infrastructure_component, 
-        infrastructure: @infrastructure,
-        hostname:       'test-kafka-02',
-        component_type: 'kafka',
-        ipaddress:      '127.0.0.16'
       )
     end
 
@@ -36,7 +30,7 @@ module ChefHelper
           @producer_component,
           @infrastructure.infrastructure_components
         )
-        
+
         attrs = producer_attributes.generate
 
         expect(attrs).to eq({
@@ -53,7 +47,7 @@ module ChefHelper
                 "version"=>"v0.11.8",
                 "env_vars"=>{
                   "BARITO_CONSUL_URL"=>"http://#{@consul_component.ipaddress}:8500",
-                  "BARITO_KAFKA_BROKERS"=>"#{@kafka_component_2.ipaddress}:9092,#{@kafka_component_1.ipaddress}:9092",
+                  "BARITO_KAFKA_BROKERS"=>"#{@kafka_component_1.ipaddress}:9092",
                   "BARITO_PRODUCER_ADDRESS"=>":8080",
                   "BARITO_PRODUCER_MAX_TPS"=>@infrastructure.options['max_tps'],
                   "BARITO_CONSUL_KAFKA_NAME"=>"kafka",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,6 @@ require 'database_cleaner'
 require 'fakeredis/rspec'
 require 'coveralls'
 require 'webdrivers'
-require 'selenium/webdriver'
 require 'simplecov'
 require 'simplecov-console'
 require 'sidekiq/testing'
@@ -34,21 +33,12 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
-# Patch for issue with Chrome 75
-# Ref: https://github.com/titusfortner/webdrivers/issues/126#issuecomment-499972539
-Webdrivers.cache_time = 1
-Webdrivers::Chromedriver.required_version = '74.0.3729.6'
-
 # Configure Capybara Driver
 Capybara.server = :puma, { Silent: true }
 Capybara.register_driver :custom_headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu no-sandbox) }
-  )
-
   Capybara::Selenium::Driver.new app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    args: %w(headless disable-gpu no-sandbox)
 end
 Capybara.javascript_driver = :custom_headless_chrome
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,7 +38,9 @@ Capybara.server = :puma, { Silent: true }
 Capybara.register_driver :custom_headless_chrome do |app|
   Capybara::Selenium::Driver.new app,
     browser: :chrome,
-    args: %w(headless disable-gpu no-sandbox)
+    options: Selenium::WebDriver::Chrome::Options.new(
+      args: %w(headless disable-gpu no-sandbox)
+    )
 end
 Capybara.javascript_driver = :custom_headless_chrome
 


### PR DESCRIPTION
CI is fixed by:

1. Don't hardcode the version of Chrome.
2. Use another way to pass arguments to Chrome, so it'll be running headless.
3. Remove some spec. since the order of IP address supplied to the attributes generator is undefined, so the test result will become indeterminable.

Spec. removal is temporary and considerable here since the Kafka address parameter will be changed from IP address to consul DNS address. Confirmed by @fadlinurhasan.