### PR TITLE
Add API to create app group user for existing app group and gate user

### DIFF
--- a/app/controllers/api/v2/app_group_users_controller.rb
+++ b/app/controllers/api/v2/app_group_users_controller.rb
@@ -18,7 +18,7 @@ class Api::V2::AppGroupUsersController < Api::V2::BaseController
   private
 
   def validate_params
-    valid, error_response = validate_required_keys([:app_group_secret, :app_group_role, :user_email])
+    valid, error_response = validate_required_keys([:app_group_secret, :app_group_role, :gate_username])
     render json: error_response, status: error_response[:code] unless valid
   end
 
@@ -28,7 +28,7 @@ class Api::V2::AppGroupUsersController < Api::V2::BaseController
   end
 
   def set_user
-    @user = User.find_by_username_or_email(params[:user_email])
+    @user = User.find_by_username_or_email(params[:gate_username])
     render json: { success: false, errors: ['User not found'], data: nil }, status: :not_found if @user.blank?
   end
 end

--- a/app/controllers/api/v2/app_group_users_controller.rb
+++ b/app/controllers/api/v2/app_group_users_controller.rb
@@ -1,0 +1,38 @@
+class Api::V2::AppGroupUsersController < Api::V2::BaseController
+  include Wisper::Publisher
+
+  before_action :validate_params
+  before_action :set_app_group
+  before_action :set_user
+
+  def create
+    app_group_role = AppGroupRole.find_by_name(params[:app_group_role])
+
+    render(json: { success: false, errors: ['App group role not found'], data: nil }, status: :not_found) && return if app_group_role.blank?
+
+    app_group_user = AppGroupUser.create(app_group_id: @app_group.id, user_id: @user.id, role_id: app_group_role.id)
+
+    render(json: { success: false, errors: [app_group_user.errors], data: nil }, status: :unprocessable_entity) && return unless app_group_user.valid?
+
+    render json: { success: true, errors: nil, data: ['App group user created'] }, status: :ok
+  end
+
+  private
+
+  def validate_params
+    valid, error_response = validate_required_keys([:app_group_secret, :app_group_role, :user_email])
+    render json: error_response, status: error_response[:code] unless valid
+  end
+
+  def set_app_group
+    @app_group = AppGroup.find_by(secret_key: params[:app_group_secret])
+
+    render json: { success: false, errors: ['App Group not found'], data: nil }, status: :not_found if @app_group.blank?
+  end
+
+  def set_user
+    @user = User.find_by_username_or_email(params[:user_email])
+
+    render json: { success: false, errors: ['User not found'], data: nil }, status: :not_found if @user.blank?
+  end
+end

--- a/app/controllers/api/v2/app_group_users_controller.rb
+++ b/app/controllers/api/v2/app_group_users_controller.rb
@@ -7,11 +7,9 @@ class Api::V2::AppGroupUsersController < Api::V2::BaseController
 
   def create
     app_group_role = AppGroupRole.find_by_name(params[:app_group_role])
-
     render(json: { success: false, errors: ['App group role not found'], data: nil }, status: :not_found) && return if app_group_role.blank?
 
     app_group_user = AppGroupUser.create(app_group_id: @app_group.id, user_id: @user.id, role_id: app_group_role.id)
-
     render(json: { success: false, errors: [app_group_user.errors], data: nil }, status: :unprocessable_entity) && return unless app_group_user.valid?
 
     render json: { success: true, errors: nil, data: ['App group user created'] }, status: :ok
@@ -26,13 +24,11 @@ class Api::V2::AppGroupUsersController < Api::V2::BaseController
 
   def set_app_group
     @app_group = AppGroup.find_by(secret_key: params[:app_group_secret])
-
     render json: { success: false, errors: ['App Group not found'], data: nil }, status: :not_found if @app_group.blank?
   end
 
   def set_user
     @user = User.find_by_username_or_email(params[:user_email])
-
     render json: { success: false, errors: ['User not found'], data: nil }, status: :not_found if @user.blank?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,58 +10,61 @@ Rails.application.routes.draw do
     # These v1 APIs are in the process of being removed
     # Use v2 APIs instead
     post :increase_log_count,
-      to: 'apps#increase_log_count',
-      defaults: { format: :json }
+         to: 'apps#increase_log_count',
+         defaults: { format: :json }
     get :profile,
-      to: 'apps#profile',
-      defaults: { format: :json }
+        to: 'apps#profile',
+        defaults: { format: :json }
     get :profile_by_app_group,
-      to: 'apps#profile_by_app_group',
-      defaults: { format: :json }
+        to: 'apps#profile_by_app_group',
+        defaults: { format: :json }
     # get :profile_by_cluster_name,
     #   to: 'infrastructures#profile_by_cluster_name',
     #   defaults: { format: :json }
     get :authorize,
-      to: 'infrastructures#authorize_by_username',
-      defaults: { format: :json }
+        to: 'infrastructures#authorize_by_username',
+        defaults: { format: :json }
     get :profile_curator,
-      to: 'infrastructures#profile_curator',
-      defaults: { format: :json }
+        to: 'infrastructures#profile_curator',
+        defaults: { format: :json }
 
     namespace :v2 do
       post :increase_log_count,
-        to: 'apps#increase_log_count',
-        defaults: { format: :json }
+           to: 'apps#increase_log_count',
+           defaults: { format: :json }
       get :profile,
-        to: 'apps#profile',
-        defaults: { format: :json }
+          to: 'apps#profile',
+          defaults: { format: :json }
       get :profile_by_app_group,
-        to: 'apps#profile_by_app_group',
-        defaults: { format: :json }
+          to: 'apps#profile_by_app_group',
+          defaults: { format: :json }
       get :profile_by_cluster_name,
-        to: 'infrastructures#profile_by_cluster_name',
-        defaults: { format: :json }
+          to: 'infrastructures#profile_by_cluster_name',
+          defaults: { format: :json }
       get :profile_index,
-        to: 'infrastructures#profile_index',
-        defaults: { format: :json }
+          to: 'infrastructures#profile_index',
+          defaults: { format: :json }
       get :authorize,
-        to: 'infrastructures#authorize_by_username',
-        defaults: { format: :json }
+          to: 'infrastructures#authorize_by_username',
+          defaults: { format: :json }
       get :profile_curator,
-        to: 'infrastructures#profile_curator',
-        defaults: { format: :json }
+          to: 'infrastructures#profile_curator',
+          defaults: { format: :json }
       get :profile_prometheus_exporter,
-        to: 'infrastructures#profile_prometheus_exporter',
-        defaults: { format: :json }
+          to: 'infrastructures#profile_prometheus_exporter',
+          defaults: { format: :json }
       post :create_app_group,
-        to: 'app_groups#create_app_group',
-        defaults: {format: :json}
+           to: 'app_groups#create_app_group',
+           defaults: {format: :json}
       get :check_app_group,
-        to: 'app_groups#check_app_group',
-        defaults: {format: :json}
+          to: 'app_groups#check_app_group',
+          defaults: {format: :json}
       get :cluster_templates,
-        to: 'app_groups#cluster_templates',
-        defaults: {format: :json}
+          to: 'app_groups#cluster_templates',
+          defaults: {format: :json}
+      post :create_app_group_user,
+           to: 'app_group_users#create',
+           defaults: {format: :json}
     end
   end
 
@@ -74,68 +77,68 @@ Rails.application.routes.draw do
   match '/group_users/:id/set_role/:role_id', to: 'group_users#set_role', via: [:put, :patch], as: 'set_role_group_user'
 
   resources :app_group_users,
-    only: %i[create update],
-    defaults: { format: :html }
+            only: %i[create update],
+            defaults: { format: :html }
   resources :app_groups,
-    only: %i[index show new create update] do
-      member do
-        get :manage_access
-        post :bookmark
-        patch :update_app_group_name
-      end
-      collection do
-        get :search
-      end
+            only: %i[index show new create update] do
+    member do
+      get :manage_access
+      post :bookmark
+      patch :update_app_group_name
     end
+    collection do
+      get :search
+    end
+  end
   resources :apps,
-    only: %i[create destroy update],
-    defaults: { format: :html } do
-      member do
-        post :update_log_retention_days
-      end
+            only: %i[create destroy update],
+            defaults: { format: :html } do
+    member do
+      post :update_log_retention_days
     end
+  end
   resources :ext_apps,
-    defaults: { format: :html } do
-      member do
-        post :regenerate_token
-      end
+            defaults: { format: :html } do
+    member do
+      post :regenerate_token
     end
+  end
   resources :groups,
-    except: %i[edit update],
-    defaults: { format: :html }
+            except: %i[edit update],
+            defaults: { format: :html }
   resources :group_users,
-    only: %i[create update destroy],
-    defaults: { format: :html }
+            only: %i[create update destroy],
+            defaults: { format: :html }
   resources :infrastructures,
-    only: %i[show edit],
-    defaults: { format: :html } do
-      member do
-        patch :update_manifests
-        post :retry_provision
-        post :retry_provision_container
-        post :provisioning_check
-        post :retry_bootstrap
-        post :retry_bootstrap_container
-        post :schedule_delete_container
-        patch :toggle_status
-        delete :delete
-      end
+            only: %i[show edit],
+            defaults: { format: :html } do
+    member do
+      patch :update_manifests
+      post :retry_provision
+      post :retry_provision_container
+      post :provisioning_check
+      post :retry_bootstrap
+      post :retry_bootstrap_container
+      post :schedule_delete_container
+      patch :toggle_status
+      delete :delete
     end
+  end
   resources :infrastructure_components,
-    only: %i[edit update index],
-    defaults: { format: :html } do
-      member do
-        post :retry_bootstrap
-      end
+            only: %i[edit update index],
+            defaults: { format: :html } do
+    member do
+      post :retry_bootstrap
     end
+  end
   resources :cluster_templates,
-    defaults: { format: :html }
+            defaults: { format: :html }
   resources :deployment_templates,
-    defaults: { format: :html }
+            defaults: { format: :html }
 
   resources :app_group_teams,
-    only: %i[create update],
-    defaults: { format: :html }
+            only: %i[create update],
+            defaults: { format: :html }
 
   root to: 'app_groups#index', defaults: { format: :html }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,61 +10,61 @@ Rails.application.routes.draw do
     # These v1 APIs are in the process of being removed
     # Use v2 APIs instead
     post :increase_log_count,
-         to: 'apps#increase_log_count',
-         defaults: { format: :json }
+      to: 'apps#increase_log_count',
+      defaults: { format: :json }
     get :profile,
-        to: 'apps#profile',
-        defaults: { format: :json }
+      to: 'apps#profile',
+      defaults: { format: :json }
     get :profile_by_app_group,
-        to: 'apps#profile_by_app_group',
-        defaults: { format: :json }
+      to: 'apps#profile_by_app_group',
+      defaults: { format: :json }
     # get :profile_by_cluster_name,
     #   to: 'infrastructures#profile_by_cluster_name',
     #   defaults: { format: :json }
     get :authorize,
-        to: 'infrastructures#authorize_by_username',
-        defaults: { format: :json }
+      to: 'infrastructures#authorize_by_username',
+      defaults: { format: :json }
     get :profile_curator,
-        to: 'infrastructures#profile_curator',
-        defaults: { format: :json }
+      to: 'infrastructures#profile_curator',
+      defaults: { format: :json }
 
     namespace :v2 do
       post :increase_log_count,
-           to: 'apps#increase_log_count',
-           defaults: { format: :json }
+        to: 'apps#increase_log_count',
+        defaults: { format: :json }
       get :profile,
-          to: 'apps#profile',
-          defaults: { format: :json }
+        to: 'apps#profile',
+        defaults: { format: :json }
       get :profile_by_app_group,
-          to: 'apps#profile_by_app_group',
-          defaults: { format: :json }
+        to: 'apps#profile_by_app_group',
+        defaults: { format: :json }
       get :profile_by_cluster_name,
-          to: 'infrastructures#profile_by_cluster_name',
-          defaults: { format: :json }
+        to: 'infrastructures#profile_by_cluster_name',
+        defaults: { format: :json }
       get :profile_index,
-          to: 'infrastructures#profile_index',
-          defaults: { format: :json }
+        to: 'infrastructures#profile_index',
+        defaults: { format: :json }
       get :authorize,
-          to: 'infrastructures#authorize_by_username',
-          defaults: { format: :json }
+        to: 'infrastructures#authorize_by_username',
+        defaults: { format: :json }
       get :profile_curator,
-          to: 'infrastructures#profile_curator',
-          defaults: { format: :json }
+        to: 'infrastructures#profile_curator',
+        defaults: { format: :json }
       get :profile_prometheus_exporter,
-          to: 'infrastructures#profile_prometheus_exporter',
-          defaults: { format: :json }
+        to: 'infrastructures#profile_prometheus_exporter',
+        defaults: { format: :json }
       post :create_app_group,
-           to: 'app_groups#create_app_group',
-           defaults: {format: :json}
+        to: 'app_groups#create_app_group',
+        defaults: {format: :json}
       get :check_app_group,
-          to: 'app_groups#check_app_group',
-          defaults: {format: :json}
+        to: 'app_groups#check_app_group',
+        defaults: {format: :json}
       get :cluster_templates,
-          to: 'app_groups#cluster_templates',
-          defaults: {format: :json}
+        to: 'app_groups#cluster_templates',
+        defaults: {format: :json}
       post :create_app_group_user,
-           to: 'app_group_users#create',
-           defaults: {format: :json}
+        to: 'app_group_users#create',
+        defaults: {format: :json}
     end
   end
 
@@ -77,68 +77,68 @@ Rails.application.routes.draw do
   match '/group_users/:id/set_role/:role_id', to: 'group_users#set_role', via: [:put, :patch], as: 'set_role_group_user'
 
   resources :app_group_users,
-            only: %i[create update],
-            defaults: { format: :html }
+    only: %i[create update],
+    defaults: { format: :html }
   resources :app_groups,
-            only: %i[index show new create update] do
-    member do
-      get :manage_access
-      post :bookmark
-      patch :update_app_group_name
+    only: %i[index show new create update] do
+      member do
+        get :manage_access
+        post :bookmark
+        patch :update_app_group_name
+      end
+      collection do
+        get :search
+      end
     end
-    collection do
-      get :search
-    end
-  end
   resources :apps,
-            only: %i[create destroy update],
-            defaults: { format: :html } do
-    member do
-      post :update_log_retention_days
+    only: %i[create destroy update],
+    defaults: { format: :html } do
+      member do
+        post :update_log_retention_days
+      end
     end
-  end
   resources :ext_apps,
-            defaults: { format: :html } do
-    member do
-      post :regenerate_token
+    defaults: { format: :html } do
+      member do
+        post :regenerate_token
+      end
     end
-  end
   resources :groups,
-            except: %i[edit update],
-            defaults: { format: :html }
+    except: %i[edit update],
+    defaults: { format: :html }
   resources :group_users,
-            only: %i[create update destroy],
-            defaults: { format: :html }
+    only: %i[create update destroy],
+    defaults: { format: :html }
   resources :infrastructures,
-            only: %i[show edit],
-            defaults: { format: :html } do
-    member do
-      patch :update_manifests
-      post :retry_provision
-      post :retry_provision_container
-      post :provisioning_check
-      post :retry_bootstrap
-      post :retry_bootstrap_container
-      post :schedule_delete_container
-      patch :toggle_status
-      delete :delete
+    only: %i[show edit],
+    defaults: { format: :html } do
+      member do
+        patch :update_manifests
+        post :retry_provision
+        post :retry_provision_container
+        post :provisioning_check
+        post :retry_bootstrap
+        post :retry_bootstrap_container
+        post :schedule_delete_container
+        patch :toggle_status
+        delete :delete
+      end
     end
-  end
   resources :infrastructure_components,
-            only: %i[edit update index],
-            defaults: { format: :html } do
-    member do
-      post :retry_bootstrap
+    only: %i[edit update index],
+    defaults: { format: :html } do
+      member do
+        post :retry_bootstrap
+      end
     end
-  end
   resources :cluster_templates,
-            defaults: { format: :html }
+    defaults: { format: :html }
   resources :deployment_templates,
-            defaults: { format: :html }
+    defaults: { format: :html }
 
   resources :app_group_teams,
-            only: %i[create update],
-            defaults: { format: :html }
+    only: %i[create update],
+    defaults: { format: :html }
 
   root to: 'app_groups#index', defaults: { format: :html }
 end

--- a/spec/requests/api/v2/app_group_users_spec.rb
+++ b/spec/requests/api/v2/app_group_users_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe 'App Groups User API', type: :request do
+  let(:headers) do
+    { 'ACCEPT' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  end
+
+  before(:all) do
+    @access_token = 'ABC123'
+    @ext_app = create(:ext_app, access_token: @access_token)
+  end
+
+  after(:all) do
+    @ext_app.destroy
+  end
+
+
+  describe 'Create an app group user' do
+    let(:app_group) { create(:app_group) }
+    let(:user) { create(:user) }
+    let(:role) { create(:app_group_role, :admin) }
+    let(:app_group_user_params) { { access_token: @access_token, app_group_secret: app_group.secret_key, app_group_role: role.name, user_email: user.email } }
+
+    context 'app group user creation successful' do
+      it 'returns success response' do
+
+        post api_v2_create_app_group_user_path, params: app_group_user_params, headers: headers
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['data']).to eq(["App group user created"])
+        expect(json_response['success']).to eq(true)
+
+        expect(AppGroupUser.first.app_group_id).to eq(app_group.id)
+        expect(AppGroupUser.first.role.id).to eq(role.id)
+        expect(AppGroupUser.first.user_id).to eq(user.id)
+      end
+    end
+
+    context 'app group user creation unsuccessful' do
+      it 'when appgroup secret is not provided it should return 422' do
+        error_msg = 'Invalid Params: app_group_secret is a required parameter'
+        post api_v2_create_app_group_user_path, params: app_group_user_params.except(:app_group_secret), headers: headers
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['code']).to eq(422)
+        expect(json_response['errors']).to eq([error_msg])
+      end
+
+      it 'when user email is not provided it should return 422' do
+        error_msg = 'Invalid Params: user_email is a required parameter'
+        post api_v2_create_app_group_user_path, params: app_group_user_params.except(:user_email), headers: headers
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['code']).to eq(422)
+        expect(json_response['errors']).to eq([error_msg])
+      end
+
+      it 'when app_group_role is not provided it should return 422' do
+        error_msg = 'Invalid Params: app_group_role is a required parameter'
+        post api_v2_create_app_group_user_path, params: app_group_user_params.except(:app_group_role), headers: headers
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['code']).to eq(422)
+        expect(json_response['errors']).to eq([error_msg])
+      end
+
+      it 'when app group user creation fails' do
+        allow_any_instance_of(AppGroupUser).to receive(:valid?).and_return(false)
+        allow_any_instance_of(AppGroupUser).to receive(:errors).and_return('some error')
+
+        post api_v2_create_app_group_user_path, params: app_group_user_params, headers: headers
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['success']).to eq(false)
+        expect(json_response['errors']).to eq(['some error'])
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/app_group_users_spec.rb
+++ b/spec/requests/api/v2/app_group_users_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'App Groups User API', type: :request do
     let(:app_group) { create(:app_group) }
     let(:user) { create(:user) }
     let(:role) { create(:app_group_role, :admin) }
-    let(:app_group_user_params) { { access_token: @access_token, app_group_secret: app_group.secret_key, app_group_role: role.name, user_email: user.email } }
+    let(:app_group_user_params) { { access_token: @access_token, app_group_secret: app_group.secret_key, app_group_role: role.name, gate_username: user.username } }
 
     context 'app group user creation successful' do
       it 'returns success response' do
@@ -46,9 +46,9 @@ RSpec.describe 'App Groups User API', type: :request do
         expect(json_response['errors']).to eq([error_msg])
       end
 
-      it 'when user email is not provided it should return 422' do
-        error_msg = 'Invalid Params: user_email is a required parameter'
-        post api_v2_create_app_group_user_path, params: app_group_user_params.except(:user_email), headers: headers
+      it 'when username is not provided it should return 422' do
+        error_msg = 'Invalid Params: gate_username is a required parameter'
+        post api_v2_create_app_group_user_path, params: app_group_user_params.except(:gate_username), headers: headers
         json_response = JSON.parse(response.body)
 
         expect(json_response['code']).to eq(422)


### PR DESCRIPTION
This API is created for the purpose of adding existing users to an app group, which will be accessible publicly and will be used to manage Barito user management from external apps in a better way.