### PR TITLE
fix(ruby): helm infrastructure to generate non duplicating cluster names.

### DIFF
--- a/app/models/helm_infrastructure.rb
+++ b/app/models/helm_infrastructure.rb
@@ -1,7 +1,9 @@
 class HelmInfrastructure < ApplicationRecord
-  belongs_to :app_group
-  belongs_to :helm_cluster_template
+  belongs_to :app_group, required: true
+  belongs_to :helm_cluster_template, required: true
+
   validates :override_values, helm_values: true
+  validates :cluster_name, uniqueness: true
 
   enum statuses: {
     inactive: 'INACTIVE',

--- a/app/models/helm_infrastructure.rb
+++ b/app/models/helm_infrastructure.rb
@@ -46,7 +46,7 @@ class HelmInfrastructure < ApplicationRecord
     end
 
     def generate_cluster_index
-      HelmInfrastructure.all.size + CLUSTER_NAME_PADDING
+      CLUSTER_NAME_PADDING + count
     end
   end
 

--- a/app/models/helm_infrastructure.rb
+++ b/app/models/helm_infrastructure.rb
@@ -1,5 +1,4 @@
 class HelmInfrastructure < ApplicationRecord
-  CLUSTER_NAME_PADDING = 1000
   belongs_to :app_group
   belongs_to :helm_cluster_template
   validates :override_values, helm_values: true
@@ -46,7 +45,9 @@ class HelmInfrastructure < ApplicationRecord
     end
 
     def generate_cluster_index
-      CLUSTER_NAME_PADDING + count
+      column = 'cluster_index'
+      query = "SELECT nextval('cluster_index_seq') AS #{column}"
+      connection.execute(query).first[column]
     end
   end
 

--- a/app/models/helm_infrastructure.rb
+++ b/app/models/helm_infrastructure.rb
@@ -19,29 +19,35 @@ class HelmInfrastructure < ApplicationRecord
     finished: 'FINISHED',
   }
 
-  def self.setup(params)
-    helm_cluster_template = HelmClusterTemplate.find(params[:helm_cluster_template_id])
-    helm_infrastructure = HelmInfrastructure.new(
-      cluster_name:               Rufus::Mnemo.from_i(HelmInfrastructure.generate_cluster_index),
-      app_group_id:               params[:app_group_id],
-      helm_cluster_template_id:   helm_cluster_template.id,
-      is_active:                  true,
-      use_k8s_kibana:             true,
-      override_values:            YAML.safe_load('{}'),
-      provisioning_status:        HelmInfrastructure.provisioning_statuses[:pending],
-      status:                     HelmInfrastructure.statuses[:inactive],
-      max_tps:                    Figaro.env.DEFAULT_MAX_TPS
-    )
+  class << self
+    def setup(params)
+      helm_cluster_template = HelmClusterTemplate.find(params[:helm_cluster_template_id])
+      helm_infrastructure = HelmInfrastructure.new(
+        cluster_name:               Rufus::Mnemo.from_i(HelmInfrastructure.generate_cluster_index),
+        app_group_id:               params[:app_group_id],
+        helm_cluster_template_id:   helm_cluster_template.id,
+        is_active:                  true,
+        use_k8s_kibana:             true,
+        override_values:            YAML.safe_load('{}'),
+        provisioning_status:        HelmInfrastructure.provisioning_statuses[:pending],
+        status:                     HelmInfrastructure.statuses[:inactive],
+        max_tps:                    Figaro.env.DEFAULT_MAX_TPS
+      )
 
-    if helm_infrastructure.valid?
-      helm_infrastructure.save
-      helm_infrastructure.update_provisioning_status('PENDING')
-      helm_infrastructure.update!(last_log: "Helm invocation job will be scheduled.")
+      if helm_infrastructure.valid?
+        helm_infrastructure.save
+        helm_infrastructure.update_provisioning_status('PENDING')
+        helm_infrastructure.update!(last_log: "Helm invocation job will be scheduled.")
 
-      helm_infrastructure.reload
-      helm_infrastructure.synchronize_async
+        helm_infrastructure.reload
+        helm_infrastructure.synchronize_async
+      end
+      helm_infrastructure
     end
-    helm_infrastructure
+
+    def generate_cluster_index
+      HelmInfrastructure.all.size + CLUSTER_NAME_PADDING
+    end
   end
 
   def synchronize_async
@@ -73,10 +79,6 @@ class HelmInfrastructure < ApplicationRecord
 
   def app_group_secret
     app_group&.secret_key
-  end
-
-  def self.generate_cluster_index
-    HelmInfrastructure.all.size + CLUSTER_NAME_PADDING
   end
 
   def active?

--- a/app/validators/helm_values_validator.rb
+++ b/app/validators/helm_values_validator.rb
@@ -1,8 +1,7 @@
 class HelmValuesValidator < ActiveModel::EachValidator
-
-  def validate_each(record, attribute, value)
-    unless value.is_a? Hash
-      record.errors.add :values, "Invalid Helm values"
+  def validate_each(record, _attribute, value)
+    unless value.is_a?(Hash)
+      record.errors.add(:values, 'Invalid Helm Values')
     end
- end
+  end
 end

--- a/db/migrate/20210723011211_add_cluster_index_sequence.rb
+++ b/db/migrate/20210723011211_add_cluster_index_sequence.rb
@@ -2,7 +2,7 @@ class AddClusterIndexSequence < ActiveRecord::Migration[5.2]
   def up
     execute <<-SQL
       CREATE SEQUENCE cluster_index_seq;
-      SELECT setval('cluster_index_seq', 1000 + 2 * (COUNT(*) + 1)) FROM infrastructures;
+      SELECT setval('cluster_index_seq', 1000 + 4 * (COUNT(*) + 1)) FROM helm_infrastructures;
     SQL
   end
 

--- a/db/migrate/20210723011211_add_cluster_index_sequence.rb
+++ b/db/migrate/20210723011211_add_cluster_index_sequence.rb
@@ -1,0 +1,14 @@
+class AddClusterIndexSequence < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+      CREATE SEQUENCE cluster_index_seq;
+      SELECT setval('cluster_index_seq', 1000 + 2 * (COUNT(*) + 1)) FROM infrastructures;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP SEQUENCE cluster_index_seq;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_23_000000) do
+ActiveRecord::Schema.define(version: 2021_07_23_011211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2021_06_23_000000) do
 
   create_table "cluster_templates", force: :cascade do |t|
     t.string "name"
-    t.jsonb "manifest"
+    t.jsonb "instances"
     t.jsonb "options"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -118,12 +118,6 @@ ActiveRecord::Schema.define(version: 2021_06_23_000000) do
     t.index ["created_by_id"], name: "index_ext_apps_on_created_by_id"
     t.index ["hashed_access_token"], name: "index_ext_apps_on_hashed_access_token"
     t.index ["name"], name: "index_ext_apps_on_name", unique: true
-  end
-
-  create_table "group_roles", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "group_users", force: :cascade do |t|
@@ -194,7 +188,7 @@ ActiveRecord::Schema.define(version: 2021_06_23_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "cluster_template_id"
-    t.jsonb "manifest", default: {}, null: false
+    t.jsonb "instances", default: {}, null: false
     t.jsonb "options", default: {}, null: false
     t.jsonb "manifests", default: {}, null: false
     t.index ["app_group_id"], name: "index_infrastructures_on_app_group_id"

--- a/spec/factories/helm_cluster_templates.rb
+++ b/spec/factories/helm_cluster_templates.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :helm_cluster_template do
-    name Faker::Lorem.word
-    values { { "key" => Faker::Lorem.word } }
+    sequence(:name) { Faker::Lorem.word }
+    values { { 'key' => Faker::Lorem.word } }
     max_tps 1
   end
 end

--- a/spec/factories/helm_infrastructures.rb
+++ b/spec/factories/helm_infrastructures.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     association :helm_cluster_template
     override_values { {} }
     last_log "MyText"
-    cluster_name          Rufus::Mnemo.from_i(1000)
+    sequence(:cluster_name) { Rufus::Mnemo.from_integer(HelmInfrastructure.generate_cluster_index) }
     provisioning_status   HelmInfrastructure.provisioning_statuses[:pending]
     status                HelmInfrastructure.statuses[:inactive]
     max_tps         [10, 100, 1000].sample

--- a/spec/models/helm_infrastructure_spec.rb
+++ b/spec/models/helm_infrastructure_spec.rb
@@ -38,17 +38,21 @@ RSpec.describe HelmInfrastructure, type: :model do
   end
 
   describe '.generate_cluster_index' do
-    it 'by default generates cluster index equal to padding when total count = 0' do
-      expect(described_class.generate_cluster_index).to eq(described_class::CLUSTER_NAME_PADDING)
+    context 'WHEN total count is 0' do
+      it 'BY DEFAULT generates cluster index greater than seed' do
+        expect(described_class.generate_cluster_index).to be > sequence_seed(0)
+      end
     end
 
-    it 'generates cluster index based on total count and padding' do
-      helm_infrastructures = Array.new(3) { create(:helm_infrastructure) }
-      cluster_index = described_class::CLUSTER_NAME_PADDING + helm_infrastructures.count
-      expect(described_class.generate_cluster_index).to eq(cluster_index)
+    context 'WHEN total count is not 0' do
+      it 'generates next cluster index greater than seed' do
+        total_count = 3
+        Array.new(total_count) { create(:helm_infrastructure) }
+        expect(described_class.generate_cluster_index).to be > sequence_seed(total_count)
+      end
     end
 
-    it 'generates overlapping cluster index to infrastructure causing duplicate cluster names' do
+    it 'generates NO overlapping cluster index to infrastructure causing duplicate cluster names' do
       total_count = 5
       infrastructure_clusters = Array.new(total_count) do
         create(:infrastructure)
@@ -58,7 +62,11 @@ RSpec.describe HelmInfrastructure, type: :model do
         create(:helm_infrastructure)
         Rufus::Mnemo.from_integer(HelmInfrastructure.generate_cluster_index)
       end.to_set
-      expect(infrastructure_clusters).to eq(helm_infrastructure_clusters)
+      expect(infrastructure_clusters & helm_infrastructure_clusters).to be_empty
+    end
+
+    def sequence_seed(total_count)
+      1000 + 2 * (total_count + 1)
     end
   end
 end

--- a/spec/models/helm_infrastructure_spec.rb
+++ b/spec/models/helm_infrastructure_spec.rb
@@ -1,24 +1,40 @@
 require 'rails_helper'
 
 RSpec.describe HelmInfrastructure, type: :model do
-  subject { create(:helm_infrastructure) }
+  context 'validates' do
+    describe ':override_values' do
+      context 'Nil (default value) is a valid Override Values' do
+        subject { build(:helm_infrastructure, override_values: nil) }
 
-  let(:app_group) { create(:app_group) }
-  let(:helm_cluster_template) { create(:helm_cluster_template) }
+        it { is_expected.to validate_helm_values_of(:override_values) }
+      end
 
-  it 'raises error if invalid override values' do
-    # noinspection RubyResolve
-    subject.override_values = ''
-    expect(subject).to_not be_valid
+      context 'Hash is a valid Override Values' do
+        subject { build(:helm_infrastructure, override_values: {}) }
+
+        it { is_expected.to validate_helm_values_of(:override_values) }
+      end
+
+      context 'String is an invalid Override Values' do
+        subject { build(:helm_infrastructure, override_values: '') }
+
+        it { is_expected.to_not validate_helm_values_of(:override_values) }
+      end
+    end
   end
 
-  it 'should create the helm_infrastructure' do
-    helm_infrastructure = HelmInfrastructure.setup(
-      app_group_id: app_group.id,
-      helm_cluster_template_id: helm_cluster_template.id,
-    )
+  describe '.setup' do
+    let(:app_group) { create(:app_group) }
+    let(:helm_cluster_template) { create(:helm_cluster_template) }
 
-    expect(helm_infrastructure.persisted?).to eq(true)
+    it 'should create the helm_infrastructure' do
+      helm_infrastructure = HelmInfrastructure.setup(
+        app_group_id: app_group.id,
+        helm_cluster_template_id: helm_cluster_template.id,
+        )
+
+      expect(helm_infrastructure).to be_persisted
+    end
   end
 
   describe '.generate_cluster_index' do

--- a/spec/models/helm_infrastructure_spec.rb
+++ b/spec/models/helm_infrastructure_spec.rb
@@ -31,21 +31,34 @@ RSpec.describe HelmInfrastructure, type: :model do
       helm_infrastructure = HelmInfrastructure.setup(
         app_group_id: app_group.id,
         helm_cluster_template_id: helm_cluster_template.id,
-        )
+      )
 
       expect(helm_infrastructure).to be_persisted
     end
   end
 
   describe '.generate_cluster_index' do
-    it 'by default generates cluster index equal to cluster padding' do
+    it 'by default generates cluster index equal to padding when total count = 0' do
       expect(described_class.generate_cluster_index).to eq(described_class::CLUSTER_NAME_PADDING)
     end
 
-    it 'generates cluster index based on count' do
-      infrastructures = Array.new(3) { create(:helm_infrastructure) }
-      cluster_index = described_class::CLUSTER_NAME_PADDING + infrastructures.count
+    it 'generates cluster index based on total count and padding' do
+      helm_infrastructures = Array.new(3) { create(:helm_infrastructure) }
+      cluster_index = described_class::CLUSTER_NAME_PADDING + helm_infrastructures.count
       expect(described_class.generate_cluster_index).to eq(cluster_index)
+    end
+
+    it 'generates overlapping cluster index to infrastructure causing duplicate cluster names' do
+      total_count = 5
+      infrastructure_clusters = Array.new(total_count) do
+        create(:infrastructure)
+        Rufus::Mnemo.from_integer(Infrastructure.generate_cluster_index)
+      end.to_set
+      helm_infrastructure_clusters = Array.new(total_count) do
+        create(:helm_infrastructure)
+        Rufus::Mnemo.from_integer(HelmInfrastructure.generate_cluster_index)
+      end.to_set
+      expect(infrastructure_clusters).to eq(helm_infrastructure_clusters)
     end
   end
 end

--- a/spec/models/helm_infrastructure_spec.rb
+++ b/spec/models/helm_infrastructure_spec.rb
@@ -2,11 +2,13 @@ require 'rails_helper'
 
 RSpec.describe HelmInfrastructure, type: :model do
   subject { create(:helm_infrastructure) }
+
   let(:app_group) { create(:app_group) }
   let(:helm_cluster_template) { create(:helm_cluster_template) }
 
   it 'raises error if invalid override values' do
-    subject.override_values = ""
+    # noinspection RubyResolve
+    subject.override_values = ''
     expect(subject.valid?).to eq false
   end
 
@@ -19,4 +21,15 @@ RSpec.describe HelmInfrastructure, type: :model do
     expect(helm_infrastructure.persisted?).to eq(true)
   end
 
+  describe '.generate_cluster_index' do
+    it 'by default generates cluster index equal to cluster padding' do
+      expect(described_class.generate_cluster_index).to eq(described_class::CLUSTER_NAME_PADDING)
+    end
+
+    it 'generates cluster index based on count' do
+      infrastructures = Array.new(3) { create(:helm_infrastructure) }
+      cluster_index = described_class::CLUSTER_NAME_PADDING + infrastructures.count
+      expect(described_class.generate_cluster_index).to eq(cluster_index)
+    end
+  end
 end

--- a/spec/models/helm_infrastructure_spec.rb
+++ b/spec/models/helm_infrastructure_spec.rb
@@ -1,7 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe HelmInfrastructure, type: :model do
+  context 'relations' do
+    it { is_expected.to belong_to(:app_group).required }
+    it { is_expected.to belong_to(:helm_cluster_template).required }
+  end
+
   context 'validates' do
+    describe ':cluster_name' do
+      subject { create(:helm_infrastructure) }
+
+      it { is_expected.to validate_uniqueness_of(:cluster_name) }
+    end
+
     describe ':override_values' do
       context 'Nil (default value) is a valid Override Values' do
         subject { build(:helm_infrastructure, override_values: nil) }

--- a/spec/models/helm_infrastructure_spec.rb
+++ b/spec/models/helm_infrastructure_spec.rb
@@ -65,8 +65,10 @@ RSpec.describe HelmInfrastructure, type: :model do
       expect(infrastructure_clusters & helm_infrastructure_clusters).to be_empty
     end
 
+    private
+
     def sequence_seed(total_count)
-      1000 + 2 * (total_count + 1)
+      1000 + 4 * (total_count + 1)
     end
   end
 end

--- a/spec/models/helm_infrastructure_spec.rb
+++ b/spec/models/helm_infrastructure_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe HelmInfrastructure, type: :model do
   it 'raises error if invalid override values' do
     # noinspection RubyResolve
     subject.override_values = ''
-    expect(subject.valid?).to eq false
+    expect(subject).to_not be_valid
   end
 
   it 'should create the helm_infrastructure' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,13 +27,7 @@ require 'datadog/statsd'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/helpers/*.rb')].each do |helper_file|
-  require(helper_file)
-end
-
-Dir[Rails.root.join('spec/support/matchers/*.rb')].each do |matcher_file|
-  require(matcher_file)
-end
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,7 +27,13 @@ require 'datadog/statsd'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/helpers/*.rb')].each do |helper_file|
+  require(helper_file)
+end
+
+Dir[Rails.root.join('spec/support/matchers/*.rb')].each do |matcher_file|
+  require(matcher_file)
+end
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/helpers/strings_helper.rb
+++ b/spec/support/helpers/strings_helper.rb
@@ -1,0 +1,10 @@
+module StringsHelper
+  def blank_string?(value)
+    if String === value
+      match_value = value.strip
+      ['', "\n", "\r", "\t", "\f"].any? do |empty_value|
+        empty_value == match_value
+      end
+    end
+  end
+end

--- a/spec/support/matchers/validate_helm_values_of_matcher.rb
+++ b/spec/support/matchers/validate_helm_values_of_matcher.rb
@@ -1,3 +1,5 @@
+require_relative '../helpers/strings_helper'
+
 module Shoulda
   module Matchers
     module ActiveModel

--- a/spec/support/matchers/validate_helm_values_of_matcher.rb
+++ b/spec/support/matchers/validate_helm_values_of_matcher.rb
@@ -1,0 +1,39 @@
+module Shoulda
+  module Matchers
+    module ActiveModel
+      def validate_helm_values_of(attribute)
+        ValidateHelmValuesOfMatcher.new(attribute)
+      end
+
+      class ValidateHelmValuesOfMatcher
+        include ::StringsHelper
+
+        def initialize(attribute)
+          @attribute = attribute
+        end
+
+        def matches?(subject)
+          value = subject.public_send(@attribute)
+          value.nil? || (!blank_string?(value) && Hash === value)
+        end
+
+        def does_not_match?(subject)
+          value = subject.public_send(@attribute)
+          !value.nil? && !(Hash === value)
+        end
+
+        def failure_message
+          "Expected an #{@attribute}, to be a Helm Value (Hash)"
+        end
+
+        def failure_message_when_negated
+          "Didn't expect #{@attribute}, to be a Helm Value (Hash)"
+        end
+
+        def description
+          "validate that :#{@attribute} can be a Helm Value (Hash)"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Modify helm infrastructure to generate non duplicating cluster names with lxc infrastructure.

This issue caused duplicated infrastructure. And, deleting them caused existing k8s stateful components to get deleted too.

Reviewed-By: Project Barito Contriubutors
