### PR TITLE
Fix newly created user is not added into global-viewer group

### DIFF
--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -3,6 +3,6 @@ class GroupUser < ActiveRecord::Base
   belongs_to :user
   belongs_to :role, class_name: 'AppGroupRole'
 
-  validates :group_id, :user_id, :role_id, presence: true
+  validates :group_id, :user_id, presence: true
   validates :group_id, uniqueness: { scope: :user_id }
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -3,6 +3,6 @@ class GroupUser < ActiveRecord::Base
   belongs_to :user
   belongs_to :role, class_name: 'AppGroupRole'
 
-  validates :group_id, :user_id, presence: true
+  validates :group_id, :user_id, :role_id, presence: true
   validates :group_id, uniqueness: { scope: :user_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,9 +26,11 @@ class User < ApplicationRecord
 
   def add_global_viewer_group
     group = Group.find_by(name: Figaro.env.global_viewer_role)
+    group_role = AppGroupRole.find_by_name('member')
     group_user = GroupUser.create(
       group_id: group.id,
-      user_id: self.id
+      user_id: self.id,
+      role_id: group_role.id
     )
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  if Figaro.env.global_viewer == "true"
+    before(:each) do
+      create(:group, name: Figaro.env.global_viewer_role)
+      @role = create(:app_group_role)
+    end
+  end
+
   describe '#self.find_by_username_or_email' do
     before(:each) do
       @user = create(:user, username: 'test_user', email: 'test@test.com')
@@ -82,7 +89,7 @@ RSpec.describe User, type: :model do
     let!(:app_group) { create(:app_group) }
 
     it 'should filter out unassociated app group' do
-      app_groups = user.filter_accessible_app_groups(AppGroup.all)
+      app_groups = user.filter_accessible_app_groups(AppGroup.all, roles: @role)
       expect(app_groups.exists?).to be false
     end
 
@@ -156,7 +163,7 @@ RSpec.describe User, type: :model do
     let!(:group) { create(:group) }
 
     it 'should filter out unassociated app group' do
-      groups = user.filter_accessible_user_groups(Group.all)
+      groups = user.filter_accessible_user_groups(Group.all, roles: @role)
       expect(groups.exists?).to be false
     end
 


### PR DESCRIPTION
Remove validation for `role_id` attribute at GroupUser model.

Fixes https://github.com/BaritoLog/BaritoMarket/issues/246