### PR TITLE
Fix/baritoappgroupparam

### DIFF
--- a/app/controllers/api/v2/app_groups_controller.rb
+++ b/app/controllers/api/v2/app_groups_controller.rb
@@ -178,7 +178,7 @@ class Api::V2::AppGroupsController < Api::V2::BaseController
   private
 
   def app_group_params
-    params.permit(:name, :cluster_template_id,
+    params.permit(:name, :cluster_template_id, :environment,
       labels: {},
     )
   end

--- a/app/models/app_group.rb
+++ b/app/models/app_group.rb
@@ -98,6 +98,8 @@ class AppGroup < ApplicationRecord
 
     if params[:labels].nil? || params[:labels].empty?
       labels = {}
+    else
+      labels = params[:labels]
     end
 
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
- add `labels` param in appgroup , so that after we add team/substream via `new application group` it will appear to in `application group detail`
- add `environment` appgroup permit, to allow add environmet if we create app group via API 