### PR TITLE
fix: make action buttons clickable on the whole button area

### DIFF
--- a/app/views/app_groups/_list.html.slim
+++ b/app/views/app_groups/_list.html.slim
@@ -72,9 +72,9 @@ table.table.table-hover.table-sm
             br
         td.col-2 class="d-flex"
           - if policy(app_group).see_app_groups?
-            .btn.btn-primary.btn-sm style="height: fit-content;"
+            = link_to "#{Figaro.env.viewer_protocol}://#{viewer_domain}/#{app_group.cluster_name}/", class: 'btn btn-primary btn-sm text-light', target: '_blank', rel: 'noopener noreferrer', style: 'height: fit-content; text-decoration: none' do
               i.fas.fa-search.mr-1
-              = link_to 'Open Kibana', "#{Figaro.env.viewer_protocol}://#{viewer_domain}/#{app_group.cluster_name}/", class: 'text-light', target: '_blank', rel: 'noopener noreferrer', style: 'text-decoration: none'
+              | Open Kibana
             = form_for(app_group, url: bookmark_app_group_path(app_group.id), method: :post, html: { class: 'ml-1' }) do |f|
               = hidden_field_tag(:app_group_id, app_group.id)
               = f.button class: 'btn btn-sm bg-transparent text-warning'

--- a/app/views/app_groups/index.html.slim
+++ b/app/views/app_groups/index.html.slim
@@ -2,9 +2,9 @@
   h5.card-header
     | All Application Groups
     - if @allow_create_app_group
-      .btn.btn-success.btn-sm.float-right
+      = link_to new_app_group_path, class: 'btn btn-success btn-sm float-right text-light', style: 'text-decoration: none' do
         i.fas.fa-plus.mr-1
-        = link_to 'New Application Group', new_app_group_path, class: 'text-light', style: 'text-decoration: none'
+        | New Application Group
   .card-body.bg-light
     = form_for_filterrific @filterrific, html: { id: 'filterrific-no-ajax-auto-submit' } do |f|
       .row

--- a/app/views/app_groups/show.html.slim
+++ b/app/views/app_groups/show.html.slim
@@ -124,12 +124,12 @@
         - override_map = ENV['BARITO_VIEWER_DOMAIN_OVERRIDED_MAP'].to_s.split(',').map { |pair| pair.split('=') }.to_h
         - viewer_domain = override_map[location_name] || Figaro.env.viewer_domain
 
-        .btn.btn-primary.btn-sm.mr-2
+        = link_to "#{Figaro.env.viewer_protocol}://#{viewer_domain}/#{@app_group.cluster_name}/", class: 'btn btn-primary btn-sm mr-2 text-light', target: '_blank', rel: 'noopener noreferrer', style: 'text-decoration: none' do
           i.fas.fa-search.mr-1
-          = link_to 'Open Kibana', "#{Figaro.env.viewer_protocol}://#{viewer_domain}/#{@app_group.cluster_name}/", target: '_blank', rel: 'noopener noreferrer', class: 'text-light', style: 'text-decoration: none'
-        .btn.btn-primary.btn-sm.mr-2
+          | Open Kibana
+        = link_to @open_katulampa_url, class: 'btn btn-primary btn-sm mr-2 text-light', target: '_blank', rel: 'noopener noreferrer', style: 'text-decoration: none' do
           i.fas.fa-tachometer-alt.mr-1
-          = link_to 'Monitoring', @open_katulampa_url, target: '_blank', rel: 'noopener noreferrer', class: 'text-light', style: 'text-decoration: none'
+          | Monitoring
 
         .btn.btn-primary.btn-sm.mr-2 data-toggle="modal" data-target="#manage-label-modal"
           i.fa.fa-tag.mr-1


### PR DESCRIPTION
The Open Kibana, Monitoring, and New Application Group buttons were divs styled as buttons with the anchor only wrapping the text, so the icon.

Existing: link anchor only shows up when the cursor is exactly at the word
<img width="1123" height="1162" alt="image" src="https://github.com/user-attachments/assets/387a1771-ecc7-45e5-a308-2ff9dd3571f1" />

After: link anchor shows up even on the edge of the button (cursor is at the edge of the button)

<img width="1123" height="1162" alt="image" src="https://github.com/user-attachments/assets/491a4d34-64ed-416f-847c-8e611f8e46a5" />
